### PR TITLE
ensure typescript file updated when importing csv

### DIFF
--- a/src/commands/CsvCommands.ts
+++ b/src/commands/CsvCommands.ts
@@ -166,7 +166,7 @@ export default class CsvCommands {
           // Check if an option was provided
           if (defaultResx) {
             // Start the CSV data
-            CsvHelper.startCsvImporting(csvData, defaultResx, resx);
+            await CsvHelper.startCsvImporting(csvData, defaultResx, resx);
           }
         }
       } else {

--- a/src/helpers/CsvHelper.ts
+++ b/src/helpers/CsvHelper.ts
@@ -20,7 +20,7 @@ export default class CsvHelper {
    * @param impLocale 
    * @param resx 
    */
-  public static startCsvImporting(csvData: string[][], impLocale: string, resx: LocalizedResourceValue[]) {
+  public static async startCsvImporting(csvData: string[][], impLocale: string, resx: LocalizedResourceValue[]) {
     // Get the header information
     const csvHeaders = this.getHeaders(csvData);
     if (csvHeaders && csvHeaders.keyIdx !== null) {
@@ -31,11 +31,11 @@ export default class CsvHelper {
         if (impLocale === OPTION_IMPORT_ALL) {
           // Full import
           for (const localeResx of resx) {
-            ImportLocaleHelper.createLocaleFiles(localeResx, localeData);
+            await ImportLocaleHelper.createLocaleFiles(localeResx, localeData);
           }
         } else {
           // Single import
-          ImportLocaleHelper.createLocaleFiles(resx.find(r => r.key === impLocale), localeData);
+          await ImportLocaleHelper.createLocaleFiles(resx.find(r => r.key === impLocale), localeData);
         }
       }
     } else {

--- a/src/helpers/ImportLocaleHelper.ts
+++ b/src/helpers/ImportLocaleHelper.ts
@@ -3,7 +3,7 @@ import * as fs from "fs";
 import * as path from "path";
 import Logging from "../commands/Logging";
 import { LocalizedResourceValue } from "../models/Config";
-import { LocaleCsvData } from "../models/LocaleCsvInfo";
+import { LocaleCsvData, LocaleData } from "../models/LocaleCsvInfo";
 import ProjectFileHelper from "./ProjectFileHelper";
 import { CONFIG_KEY, CONFIG_FILE_EXTENSION } from "./ExtensionSettings";
 
@@ -15,7 +15,7 @@ export default class ImportLocaleHelper {
    * @param csvData 
    * @param resx 
    */
-  public static createLocaleFiles(resx: LocalizedResourceValue | undefined, localeData: LocaleCsvData | null): void {
+  public static async createLocaleFiles(resx: LocalizedResourceValue | undefined, localeData: LocaleCsvData | null) {
     if (!resx || !localeData) {
       return;
     }
@@ -24,7 +24,7 @@ export default class ImportLocaleHelper {
     if (!fileExtension) {
       fileExtension = "js";
     }
-  
+
     // Create the key in the localized resource file
     let resourcePath = ProjectFileHelper.getResourcePath(resx);
 
@@ -34,6 +34,9 @@ export default class ImportLocaleHelper {
       if (key && localLabels && localLabels.length > 0) {
         const resourceKeys = localeData[key].filter(l => l.resx === resx.key);
         if (resourceKeys && resourceKeys.length > 0) {
+
+          await this.ensureTypescriptKeysDefined(resx, localLabels)
+
           // Create the file content
           let fileContents = fileExtension === "ts" ? `declare var define: any;
        
@@ -50,6 +53,80 @@ define([], () => {
           fs.writeFileSync(fileLocation, fileContents, { encoding: "utf8" });
           Logging.info(`Localization labels have been imported.`);
         }
+      }
+    }
+  }
+
+
+  /**
+   * Ensure all lables are inserted in the definition (.d.ts) file when importing csv
+   * 
+   * @param resx
+   * @param localLabels
+  */
+  private static async ensureTypescriptKeysDefined(resx: LocalizedResourceValue, localLabels: LocaleData[]): Promise<void> {
+
+    // Create the key in the localized resource file
+    let resourcePath = ProjectFileHelper.getResourcePath(resx);
+
+    // Get all files from the localization folder
+    const definitionFiles = await vscode.workspace.findFiles(`${resourcePath}/*.d.ts`);
+
+    // nothing to update
+    if (definitionFiles.length == 0) {
+      return;
+    }
+
+    if (definitionFiles.length > 1) {
+      Logging.warning(`There is more than one typescript definition file (.d.ts), the update skipped.`);
+      return;
+    }
+
+    const fileData = await vscode.workspace.openTextDocument(definitionFiles[0]);
+    const fileName = fileData.fileName;
+    const fileContents = fileData.getText();
+    const fileLines = fileContents.split("\n");
+
+    // Create workspace edit
+    const edit = new vscode.WorkspaceEdit();
+
+    const startPos = fileLines.findIndex(line => {
+      const matches = line.trim().match(/(^declare interface|{$)/gi);
+      return matches !== null && matches.length >= 2;
+    });
+
+    // the file is non-standard
+    if (startPos === -1) {
+      Logging.warning(`The file ${fileName} does not start with 'declare interface'. File updated skipped.`);
+      return;
+    }
+
+    let applyEdit = false;
+
+    for (let localLabel of localLabels) {
+
+      const localeKey = localLabel.key;
+
+      // Check if the line was found, add the key and save the file
+      if (!fileContents.includes(`${localeKey}: string;`)) {
+        applyEdit = true;
+        const getLinePos = fileLines[startPos + 1].search(/\S|$/);
+        // Create the data to insert in the file
+        const newLineData = `${localeKey}: string;\r\n${' '.repeat(getLinePos)}`;
+        edit.insert(fileData.uri, new vscode.Position((startPos + 1), getLinePos), newLineData);
+      }
+    }
+
+    if (applyEdit) {
+      try {
+        const result = await vscode.workspace.applyEdit(edit).then(success => success);
+        if (!result) {
+          Logging.warning(`Couldn't update the typescript definition file: ${fileName}.`);
+        } else {
+          await fileData.save();
+        }
+      } catch (e) {
+        Logging.warning(`Something went wrong when updating the typescript definition file: ${fileName}.`);
       }
     }
   }


### PR DESCRIPTION
This is a fix for the #6 

Added some code to CSV import to ensure that the typescript definition file is also updated when importing data.
Means, if the CSV file contains some strings that were not yet included to the MyStrings.d.ts file, then keys for them are automatically created in this file.

This ensures that the code will compile after editing the .csv file.

Scenario this addresses: the labels are added FIRST in the CSV file (external editor for example) and then used in code. In my case, we porting an existing application to SPFx. That means, many translations are already available (in CSV). So it's kind of "CSV-first" approach :)