### PR TITLE
UTF8 BOM marker option

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ The extension has the following settings which you can configure to your own pre
 | `spfxLocalization.csvDelimiter` | The delimiter to use in the CSV file. | string | `;` |
 | `spfxLocalization.autoCsvExport` | Specify if you want to automatically export to the CSV file when creating new labels. | boolean | `false` |
 | `spfxLocalization.localeFileExtension` | Specify the extension type of the localization files. Default is JavaScript, but you can be changed to TypeScript. | enum | "js" \| "ts" |
+| `spfxLocalization.csvUseBom` | Use UTF8 BOM marker for CSV files. Can be useful on Windows to make UTF8 CSV files recognizable by Excel for example. | boolean | `false` |
 
 ## How to use this extension
 

--- a/package.json
+++ b/package.json
@@ -47,6 +47,11 @@
           "default": ";",
           "description": "The delimiter to use in the CSV file."
         },
+        "spfxLocalization.csvUseBom": {
+          "type": "boolean",
+          "default": false,
+          "description": "Use UTF8 BOM marker for CSV files. Can be useful on Windows to make UTF8 CSV files recognizable by Excel for example."
+        },
         "spfxLocalization.autoCsvExport": {
           "type": "boolean",
           "default": false,

--- a/src/commands/CsvCommands.ts
+++ b/src/commands/CsvCommands.ts
@@ -6,7 +6,7 @@ import { Config, LocalizedResourceValue } from '../models/Config';
 import ResourceHelper from '../helpers/ResourceHelper';
 import CsvHelper from '../helpers/CsvHelper';
 import ExportLocaleHelper from '../helpers/ExportLocaleHelper';
-import { CONFIG_KEY, CONFIG_CSV_DELIMITER, CONFIG_CSV_FILELOCATION, OPTION_IMPORT_ALL, CONFIG_FILE_EXTENSION } from '../helpers/ExtensionSettings';
+import { CONFIG_KEY, CONFIG_CSV_DELIMITER, CONFIG_CSV_FILELOCATION, OPTION_IMPORT_ALL, CONFIG_FILE_EXTENSION, CONFIG_CSV_USE_BOM } from '../helpers/ExtensionSettings';
 
 export default class CsvCommands {
 
@@ -84,14 +84,16 @@ export default class CsvCommands {
               throw new Error(`The "spfxLocalization.csvFileLocation" configuration setting is not provided.`);
             }
 
+            const useBom = !!vscode.workspace.getConfiguration(CONFIG_KEY).get(CONFIG_CSV_USE_BOM);
+
             // Get the CSV file or create one
             let csvData = await this.getCsvFile(true);
             if (!csvData) {
-              csvData = CsvHelper.createCsvFile(localeFiles, resource, csvFileLocation, delimiter, fileExtension);
+              csvData = CsvHelper.createCsvFile(localeFiles, resource, csvFileLocation, delimiter, fileExtension, useBom);
             }
 
             // Start the export
-            parse(csvData, { delimiter }, (err: any | Error, csvData: string[][]) => ExportLocaleHelper.startExport(err, csvData, localeFiles, csvFileLocation, delimiter as string, resource.key));
+            parse(csvData, { delimiter }, (err: any | Error, csvData: string[][]) => ExportLocaleHelper.startExport(err, csvData, localeFiles, csvFileLocation, delimiter as string, resource.key, useBom));
           }
         }
       }

--- a/src/helpers/CsvHelper.ts
+++ b/src/helpers/CsvHelper.ts
@@ -7,7 +7,7 @@ import Logging from "../commands/Logging";
 import ImportLocaleHelper from "./ImportLocaleHelper";
 import { LocaleKeyValue } from "../models/LocaleKeyValue";
 import ProjectFileHelper from "./ProjectFileHelper";
-import { OPTION_IMPORT_ALL } from "./ExtensionSettings";
+import { OPTION_IMPORT_ALL, UTF8_BOM } from "./ExtensionSettings";
 
 const LOCALE_HEADER = "Locale";
 
@@ -52,7 +52,7 @@ export default class CsvHelper {
    * @param delimiter 
    * @param fileExtension 
    */
-  public static createCsvFile(localeFiles: vscode.Uri[], resource: LocalizedResourceValue, csvFileLocation: string, delimiter: string, fileExtension: string): string {
+  public static createCsvFile(localeFiles: vscode.Uri[], resource: LocalizedResourceValue, csvFileLocation: string, delimiter: string, fileExtension: string, useBom: boolean): string {
     const locales = localeFiles.map(f => {
       const filePath = f.path.substring(f.path.lastIndexOf("/") + 1);
       return `${LOCALE_HEADER} ${filePath.replace(`.${fileExtension}`, "")}`;
@@ -60,7 +60,8 @@ export default class CsvHelper {
     // Create the headers for the CSV file
     const headers = ["key", ...locales, resource.key];
     const filePath = ProjectFileHelper.getAbsPath(csvFileLocation);
-    fs.writeFileSync(filePath, headers.join(delimiter));
+    const bom = useBom ? UTF8_BOM : '';
+    fs.writeFileSync(filePath, bom + headers.join(delimiter));
     return headers.join(delimiter);
   }
 
@@ -99,12 +100,14 @@ export default class CsvHelper {
    * @param fileLocation 
    * @param fileData 
    * @param delimiter 
+   * @param useBom
    */
-  public static writeToCsvFile(fileLocation: string, fileData: string[][], delimiter: string) {
+  public static writeToCsvFile(fileLocation: string, fileData: string[][], delimiter: string, useBom: boolean) {
     stringify(fileData, { delimiter }, (err: any | Error, output: any) => {
       if (output) {
         const filePath = ProjectFileHelper.getAbsPath(fileLocation);
-        fs.writeFileSync(filePath, output, { encoding: "utf8" });
+        const bom = useBom ? UTF8_BOM : '';
+        fs.writeFileSync(filePath, bom + output, { encoding: "utf8" });
         Logging.info(`Exported the locale data to the CSV file.`);
       } else {
         Logging.error(`Something went wrong while writing to the CSV file.`);

--- a/src/helpers/ExportLocaleHelper.ts
+++ b/src/helpers/ExportLocaleHelper.ts
@@ -15,7 +15,7 @@ export default class ExportLocaleHelper {
    * @param delimiter
    * @param resourceName
    */
-  public static async startExport(err: any | Error, csvData: string[][], localeFiles: vscode.Uri[], csvLocation: string, delimiter: string, resourceName: string): Promise<void> {
+  public static async startExport(err: any | Error, csvData: string[][], localeFiles: vscode.Uri[], csvLocation: string, delimiter: string, resourceName: string, useBom: boolean): Promise<void> {
     // Start looping over the JS Locale files
     for (const localeFile of localeFiles) {
       const localeData = await vscode.workspace.openTextDocument(localeFile);
@@ -32,6 +32,6 @@ export default class ExportLocaleHelper {
     }
 
     // Once all data has been processed, the CSV file can be created
-    CsvHelper.writeToCsvFile(csvLocation, csvData, delimiter);
+    CsvHelper.writeToCsvFile(csvLocation, csvData, delimiter, useBom);
   }
 }

--- a/src/helpers/ExtensionSettings.ts
+++ b/src/helpers/ExtensionSettings.ts
@@ -5,3 +5,6 @@ export const CONFIG_AUTO_EXPORT = "autoCsvExport";
 export const CONFIG_FILE_EXTENSION = "localeFileExtension";
 
 export const OPTION_IMPORT_ALL = "Import to all";
+
+export const CONFIG_CSV_USE_BOM = "csvUseBom";
+export const UTF8_BOM = '\ufeff';


### PR DESCRIPTION
Implementation of BOM marker option. 

Linked issue: #8 

Now if you double-click the exported CSV file on Windows, Excel (for example) does not open it properly if the file contains non-ASCII characters (!). This is kind of sad for a translation tool. Means, you may need to re-open it in Excel by specifically selecting UTF8 encoding. It is not only Excel though; the issue is quite common on Windows. But if a file contains BOM, the apps work properly.

What is BOM: https://en.wikipedia.org/wiki/Byte_order_mark

This PR adds optional support for UTF8 BOM:
![image](https://user-images.githubusercontent.com/528366/97751728-19f82500-1af3-11eb-8fa9-b3601263c434.png)

If checked, the generated CSV file will contain UTF8 BOM (FEFF).