### PR TITLE
Detect position alphabetically when inserting new key

### DIFF
--- a/src/commands/LocaleKey.ts
+++ b/src/commands/LocaleKey.ts
@@ -227,20 +227,13 @@ export class LocaleKey {
     let idx = -1;
     // Check if "d.ts" file
     if (fileData.fileName.endsWith(".d.ts")) {
-      // Check if line starts with "declare interface" and ends with "{"
-      idx = fileLines.findIndex(line => {
-        const matches = line.trim().match(/(^declare interface|{$)/gi);
-        return matches !== null && matches.length >= 2;
-      });
-    } 
+      idx = TextHelper.findInsertPosition(fileLines, localeKey, TextHelper.FindPositionTs);
+  }
 
     // Check if "js" file
     if (fileData.fileName.endsWith(".js") || (fileData.fileName.endsWith(".ts") && !fileData.fileName.endsWith(".d.ts"))) {
       // Check if line starts with "return" and ends with "{"
-      idx = fileLines.findIndex(line => {
-        const matches = line.trim().match(/(^return|{$)/gi);
-        return matches !== null && matches.length >= 2;
-      });
+      idx = TextHelper.findInsertPosition(fileLines, localeKey, TextHelper.FindPositionJs);
     }
 
     // Check if the line was found, add the key and save the file

--- a/src/helpers/CsvHelper.ts
+++ b/src/helpers/CsvHelper.ts
@@ -171,7 +171,8 @@ export default class CsvHelper {
     // Check if rowData length is equal to rowDefinition length
     if (rowData.length === rowDefinition.length) {
       // Add the new row
-      csvData.push(rowData);
+      const insertRow = this.findInsertRowForKey(csvData, keyValue.key, rowDefinition.indexOf("key"))
+      csvData.splice(insertRow, 0, rowData);
     }
 
     return csvData;
@@ -191,6 +192,24 @@ export default class CsvHelper {
       }
     }
     return null;
+  }
+
+  /**
+   * Search for proper new row insert position (compare lines by keys, stop at the first which follows the key)
+   * 
+   * @param csvData 
+   * @param localeKey 
+   */
+  private static findInsertRowForKey(csvData: string[][], localeKey: string, cellIdx: number): number {
+    let result = 1;
+    for (let i = 1; i < csvData.length; i++) {
+      const row = csvData[i];
+      const rowKey = row && row[cellIdx];
+      if (rowKey && rowKey.toLowerCase() < localeKey.toLowerCase()) {
+        result = i + 1;
+      }
+    }
+    return result;
   }
 
   /**

--- a/src/helpers/TextHelper.ts
+++ b/src/helpers/TextHelper.ts
@@ -1,4 +1,10 @@
 
+interface IFindPositionRegexSet {
+  start: RegExp;
+  line: RegExp;
+  end: RegExp;
+};
+
 export default class TextHelper {
   
   /**
@@ -20,4 +26,53 @@ export default class TextHelper {
 
     return value;
   }
+
+  //start: "declare interface {", line: "some_id: string;", end: "}" 
+  public static FindPositionTs : IFindPositionRegexSet = {
+    start: /^\s*declare\s*interface\s*(\w+)\s*\{\s*$/,
+    line:  /^\s*(\w+)\s*\:\s*string\s*;\s*$/,
+    end:   /^\s*(\})\s*$/,
+  };
+  
+  //start: "return {", line: "some_id: string,", end: "}" 
+  public static FindPositionJs : IFindPositionRegexSet = {
+    start: /^\s*(return\s*\{)\s*$/,
+    line:  /^\s*(\w+)\s*\:.*,\s*$/,
+    end:   /^\s*(\})\s*;\s*$/,
+  };
+
+    // find proper position for inserting text in typescript file
+  public static findInsertPosition(fileLines: string[], localeKey: string, regexSet: IFindPositionRegexSet): number {
+
+    let result = -1;
+    let inScope = false;
+    for (let row = 0; row < fileLines.length; ++row) {
+      const line = fileLines[row];
+
+      if (inScope) {
+        const idMatches = line.match(regexSet.line)
+        if (idMatches !== null && idMatches.length > 1) {
+          const rowKey = idMatches[1];
+          if (rowKey.toLowerCase() < localeKey.toLowerCase()) {
+            result = row;
+          }
+        }
+
+        const endMatches = line.match(regexSet.end);
+        if (endMatches !== null && endMatches.length > 1) {
+          inScope = false;
+        }
+      }
+
+      const startMatches = line.match(regexSet.start);
+      if (startMatches !== null && startMatches.length > 1) {
+        result = row;
+        inScope = true;
+      }
+     
+    }
+
+    return result;
+  }
+
 }

--- a/src/test/CsvHelper.test.ts
+++ b/src/test/CsvHelper.test.ts
@@ -1,0 +1,92 @@
+
+import * as assert from 'assert';
+import CsvHelper from '../helpers/CsvHelper';
+
+suite('CsvHelper.findInsertPosition typescript tests', () => {
+
+  const csvData = [
+    ['key', 'en-us', 'de-de', 'hw'],
+    ['BBB', 'en BBB', 'de BBB', 'x'],
+    ['DDD', 'en DDD', 'de DDD', 'x'],
+    ['FFF', 'en FFF', 'de FFF', 'x']
+  ];
+
+  test('simple insert: AAA', () => {
+    const actual = CsvHelper.updateData([...csvData], [{ key: 'AAA', value: 'AAA' }], 'en-us', 'hw');
+    const expected = [
+      ['key', 'en-us', 'de-de', 'hw'],
+      ['AAA', 'AAA', '', 'x'],
+      ['BBB', 'en BBB', 'de BBB', 'x'],
+      ['DDD', 'en DDD', 'de DDD', 'x'],
+      ['FFF', 'en FFF', 'de FFF', 'x']
+    ];
+    assert.deepStrictEqual(actual, expected);
+  });
+
+  test('simple insert: CCC', () => {
+    const actual = CsvHelper.updateData([...csvData], [{ key: 'CCC', value: 'CCC' }], 'en-us', 'hw');
+    const expected = [
+      ['key', 'en-us', 'de-de', 'hw'],
+      ['BBB', 'en BBB', 'de BBB', 'x'],
+      ['CCC', 'CCC', '', 'x'],
+      ['DDD', 'en DDD', 'de DDD', 'x'],
+      ['FFF', 'en FFF', 'de FFF', 'x']
+    ];
+    assert.deepStrictEqual(actual, expected);
+  });
+
+  test('simple insert: EEE', () => {
+    const actual = CsvHelper.updateData([...csvData], [{ key: 'EEE', value: 'EEE' }], 'en-us', 'hw');
+    const expected = [
+      ['key', 'en-us', 'de-de', 'hw'],
+      ['BBB', 'en BBB', 'de BBB', 'x'],
+      ['DDD', 'en DDD', 'de DDD', 'x'],
+      ['EEE', 'EEE', '', 'x'],
+      ['FFF', 'en FFF', 'de FFF', 'x']
+    ];
+    assert.deepStrictEqual(actual, expected);
+  });
+
+  test('simple insert: ZZZ', () => {
+    const actual = CsvHelper.updateData([...csvData], [{ key: 'ZZZ', value: 'ZZZ' }], 'en-us', 'hw');
+    const expected = [
+      ['key', 'en-us', 'de-de', 'hw'],
+      ['BBB', 'en BBB', 'de BBB', 'x'],
+      ['DDD', 'en DDD', 'de DDD', 'x'],
+      ['FFF', 'en FFF', 'de FFF', 'x'],
+      ['ZZZ', 'ZZZ', '', 'x']
+    ];
+    assert.deepStrictEqual(actual, expected);
+  });
+
+  test('empty', () => {
+    const actual = CsvHelper.updateData([], [{ key: 'ZZZ', value: 'ZZZ' }], 'en-us', 'hw');
+    const expected: string[][] = [];
+    assert.deepStrictEqual(actual, expected);
+  });
+
+  test('single line', () => {
+    const actual = CsvHelper.updateData([['key', 'en-us', 'de-de', 'hw']], [{ key: 'ZZZ', value: 'ZZZ' }], 'en-us', 'hw');
+    const expected = [
+      ['key', 'en-us', 'de-de', 'hw'],
+      ['ZZZ', 'ZZZ', '', 'x']
+    ];
+    assert.deepStrictEqual(actual, expected);
+  });
+
+  test('unsorted', () => {
+    const actual = CsvHelper.updateData([
+      ['key', 'en-us', 'de-de', 'hw'],
+      ['BBB2', 'BBB2', 'BBB2', 'x'],
+      ['BBB1', 'BBB1', 'BBB1', 'x'],
+    ], [{ key: 'BBB3', value: 'BBB3' }], 'en-us', 'hw');
+    const expected = [
+      ['key', 'en-us', 'de-de', 'hw'],
+      ['BBB2', 'BBB2', 'BBB2', 'x'],
+      ['BBB1', 'BBB1', 'BBB1', 'x'],
+      ['BBB3', 'BBB3', '', 'x'],
+    ];
+    assert.deepStrictEqual(actual, expected);
+  });
+
+});

--- a/src/test/TextHelper.test.ts
+++ b/src/test/TextHelper.test.ts
@@ -1,0 +1,132 @@
+import * as assert from 'assert';
+import TextHelper from '../helpers/TextHelper';
+
+// typescript (strings.d.ts) update tests
+suite('TextHelper.findInsertPosition typescript tests', () => {
+
+  const lines = [
+    'declare interface Foo {',
+    '  BBB: string;',
+    '  DDD: string;',
+    '  FFF: string;',
+    '}',
+  ]
+
+  test('simple insert: AAA', () => {
+    assert.strictEqual(TextHelper.findInsertPosition(lines, 'AAA', TextHelper.FindPositionTs), 0);
+  });
+  test('simple insert: CCC', () => {
+    assert.strictEqual(TextHelper.findInsertPosition(lines, 'CCC', TextHelper.FindPositionTs), 1);
+  });
+  test('simple insert: EEE', () => {
+    assert.strictEqual(TextHelper.findInsertPosition(lines, 'EEE', TextHelper.FindPositionTs), 2);
+  });
+  test('simple insert: ZZZ', () => {
+    assert.strictEqual(TextHelper.findInsertPosition(lines, 'ZZZ', TextHelper.FindPositionTs), 3);
+  });
+
+  test('default', () => {
+
+    const lines = [
+      'declare interface Foo {',
+      '}',
+    ]
+
+    assert.strictEqual(TextHelper.findInsertPosition(lines, 'BBB', TextHelper.FindPositionTs), 0);
+  });
+
+  test('invalid', () => {
+
+    const lines = [
+      'class XYZ {',
+      'AA: string;',
+      '}',
+    ]
+
+    assert.strictEqual(TextHelper.findInsertPosition(lines, 'BBB', TextHelper.FindPositionTs), -1);
+  });
+
+  test('empty', () => {
+    const lines: string[] = [];
+    assert.strictEqual(TextHelper.findInsertPosition(lines, 'BBB', TextHelper.FindPositionTs), -1);
+  });
+
+  test('unsorted', () => {
+    const lines = [
+      'declare interface Foo {',
+      '  BBB2: string;',
+      '  BBB1: string;',
+      '}',
+    ]
+    assert.strictEqual(TextHelper.findInsertPosition(lines, 'BBB3', TextHelper.FindPositionTs), 2);
+  });
+
+});
+
+
+// javascript udpate tests (en-us.js, etc)
+suite('TextHelper.findInsertPosition javascript tests', () => {
+
+  const lines = [
+    'define([], function() {',
+    'return {',
+    '  BBB: "B",',
+    '  DDD: "D",',
+    '  FFF: "F",',
+    '  };',
+    '});'
+  ]
+
+  test('simple insert: AAA', () => {
+    assert.strictEqual(TextHelper.findInsertPosition(lines, 'AAA', TextHelper.FindPositionJs), 1);
+  });
+  test('simple insert: CCC', () => {
+    assert.strictEqual(TextHelper.findInsertPosition(lines, 'CCC', TextHelper.FindPositionJs), 2);
+  });
+  test('simple insert: EEE', () => {
+    assert.strictEqual(TextHelper.findInsertPosition(lines, 'EEE', TextHelper.FindPositionJs), 3);
+  });
+  test('simple insert: ZZZ', () => {
+    assert.strictEqual(TextHelper.findInsertPosition(lines, 'ZZZ', TextHelper.FindPositionJs), 4);
+  });
+
+  test('default', () => {
+
+    const lines = [
+      'define([], function() {',
+      'return {',
+      '  };',
+      '});'
+    ];
+
+    assert.strictEqual(TextHelper.findInsertPosition(lines, 'BBB', TextHelper.FindPositionJs), 1);
+  });
+
+  test('invalid', () => {
+
+    const lines = [
+      'var xy = asdf',
+      '}',
+    ];
+
+    assert.strictEqual(TextHelper.findInsertPosition(lines, 'BBB', TextHelper.FindPositionJs), -1);
+  });
+
+  test('empty', () => {
+    const lines: string[] = [];
+    assert.strictEqual(TextHelper.findInsertPosition(lines, 'BBB', TextHelper.FindPositionJs), -1);
+  });
+
+  test('unsorted', () => {
+    const lines = [
+      'define([], function() {',
+      'return {',
+      '  BBB2: "bbb2",',
+      '  BBB1: "bbb1",',
+      '  };',
+      '});'
+    ]
+    assert.strictEqual(TextHelper.findInsertPosition(lines, 'BBB3', TextHelper.FindPositionJs), 3);
+  });
+
+});


### PR DESCRIPTION
Detect "better" insert position when adding new key (alphabetically by key)
Assumes that initially, things are sorted; if not then will just find the "next best" position (the row after one that is has preceding key)

Related issue: #12 

Also added some tests regarding this insertion. 
Please note that "npm test" runs in code only on the "insider" build of the vscode.