### PR TITLE
Comments column

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -7,5 +7,8 @@
         "out": true // set this to false to include "out" folder in search results
     },
     // Turn off tsc task auto detection since we have the necessary tasks as npm scripts
-    "typescript.tsc.autoDetect": "off"
+    "typescript.tsc.autoDetect": "off",
+
+    // use typescript version as specified in tsconfig instead of the one installed locally
+    "typescript.tsdk": "node_modules\\typescript\\lib"
 }

--- a/README.md
+++ b/README.md
@@ -66,6 +66,9 @@ The extension has the following settings which you can configure to your own pre
 | `spfxLocalization.autoCsvExport` | Specify if you want to automatically export to the CSV file when creating new labels. | boolean | `false` |
 | `spfxLocalization.localeFileExtension` | Specify the extension type of the localization files. Default is JavaScript, but you can be changed to TypeScript. | enum | "js" \| "ts" |
 | `spfxLocalization.csvUseBom` | Use UTF8 BOM marker for CSV files. Can be useful on Windows to make UTF8 CSV files recognizable by Excel for example. | boolean | `false` |
+| `spfxLocalization.csvUseComment` | Enable comment column in CSV. You can use this column for notices, such as "translated" or "new". | boolean | `false` |
+| `spfxLocalization.csvUseCommentTimestamp` | Auto-fill comment column with current timestamp when new strings are added. | boolean | `false` |
+
 
 ## How to use this extension
 

--- a/package.json
+++ b/package.json
@@ -52,6 +52,16 @@
           "default": false,
           "description": "Use UTF8 BOM marker for CSV files. Can be useful on Windows to make UTF8 CSV files recognizable by Excel for example."
         },
+        "spfxLocalization.csvUseComment": {
+          "type": "boolean",
+          "default": false,
+          "description": "Enable comment column in CSV. You can use this column for notices, such as 'translated' or 'new'."
+        },
+        "spfxLocalization.csvUseCommentTimestamp": {
+          "type": "boolean",
+          "default": false,
+          "description": "Auto-fill comment column with current timestamp when new strings are added."
+        },
         "spfxLocalization.autoCsvExport": {
           "type": "boolean",
           "default": false,

--- a/src/commands/CsvCommands.ts
+++ b/src/commands/CsvCommands.ts
@@ -6,7 +6,16 @@ import { Config, LocalizedResourceValue } from '../models/Config';
 import ResourceHelper from '../helpers/ResourceHelper';
 import CsvHelper from '../helpers/CsvHelper';
 import ExportLocaleHelper from '../helpers/ExportLocaleHelper';
-import { CONFIG_KEY, CONFIG_CSV_DELIMITER, CONFIG_CSV_FILELOCATION, OPTION_IMPORT_ALL, CONFIG_FILE_EXTENSION, CONFIG_CSV_USE_BOM } from '../helpers/ExtensionSettings';
+import { 
+  CONFIG_KEY, 
+  CONFIG_CSV_DELIMITER,
+  CONFIG_CSV_FILELOCATION,
+  OPTION_IMPORT_ALL,
+  CONFIG_FILE_EXTENSION,
+  CONFIG_CSV_USE_BOM,
+  CONFIG_CSV_USE_COMMENT,
+  CONFIG_CSV_USE_COMMENT_TIMESTAMP
+} from '../helpers/ExtensionSettings';
 
 export default class CsvCommands {
 
@@ -85,15 +94,19 @@ export default class CsvCommands {
             }
 
             const useBom = !!vscode.workspace.getConfiguration(CONFIG_KEY).get(CONFIG_CSV_USE_BOM);
+            const useComment = !!vscode.workspace.getConfiguration(CONFIG_KEY).get(CONFIG_CSV_USE_COMMENT);
+            const useCommentTimestamp = !!vscode.workspace.getConfiguration(CONFIG_KEY).get(CONFIG_CSV_USE_COMMENT_TIMESTAMP);
 
             // Get the CSV file or create one
             let csvData = await this.getCsvFile(true);
             if (!csvData) {
-              csvData = CsvHelper.createCsvFile(localeFiles, resource, csvFileLocation, delimiter, fileExtension, useBom);
+              csvData = CsvHelper.createCsvFile(localeFiles, resource, csvFileLocation, delimiter, fileExtension, useBom, useComment);
             }
 
             // Start the export
-            parse(csvData, { delimiter }, (err: any | Error, csvData: string[][]) => ExportLocaleHelper.startExport(err, csvData, localeFiles, csvFileLocation, delimiter as string, resource.key, useBom));
+            parse(csvData, { delimiter }, (err: any | Error, csvData: string[][]) => {
+              return ExportLocaleHelper.startExport(err, csvData, localeFiles, csvFileLocation, delimiter as string, resource.key, useBom, useComment, useCommentTimestamp);
+            })
           }
         }
       }

--- a/src/commands/CsvCommands.ts
+++ b/src/commands/CsvCommands.ts
@@ -58,12 +58,13 @@ export default class CsvCommands {
    */
   public static async export(resxToUse: LocalizedResourceValue | null = null) {
     try {
+      const config = vscode.workspace.getConfiguration(CONFIG_KEY);
       // Use the provided resource or ask which resource file to use
       const resources = resxToUse ? [resxToUse] : await this.getResourceToUse();
       if (resources && resources.length > 0) {
         for (const resource of resources) {
           if (resource) {
-            let fileExtension: string | undefined = vscode.workspace.getConfiguration(CONFIG_KEY).get(CONFIG_FILE_EXTENSION);
+            let fileExtension: string | undefined = config.get(CONFIG_FILE_EXTENSION);
             if (!fileExtension) {
               fileExtension = "js";
             }
@@ -80,22 +81,22 @@ export default class CsvCommands {
               localeFiles = localeFiles.filter(f => !f.path.includes("mystrings.d.ts"));
             }
 
-            let delimiter: string | undefined = vscode.workspace.getConfiguration(CONFIG_KEY).get(CONFIG_CSV_DELIMITER);
+            let delimiter: string | undefined = config.get(CONFIG_CSV_DELIMITER);
             if (!delimiter) {
               delimiter = ";";
               Logging.warning(`The delimiter setting was empty, ";" will be used instead.`);
             }
 
             // Retrieve the settings for the extension
-            const csvFileLocation: string | undefined = vscode.workspace.getConfiguration(CONFIG_KEY).get(CONFIG_CSV_FILELOCATION);
+            const csvFileLocation: string | undefined = config.get(CONFIG_CSV_FILELOCATION);
             if (!csvFileLocation) {
               Logging.error(`The "spfxLocalization.csvFileLocation" configuration setting is not provided.`);
               throw new Error(`The "spfxLocalization.csvFileLocation" configuration setting is not provided.`);
             }
 
-            const useBom = !!vscode.workspace.getConfiguration(CONFIG_KEY).get(CONFIG_CSV_USE_BOM);
-            const useComment = !!vscode.workspace.getConfiguration(CONFIG_KEY).get(CONFIG_CSV_USE_COMMENT);
-            const useCommentTimestamp = !!vscode.workspace.getConfiguration(CONFIG_KEY).get(CONFIG_CSV_USE_COMMENT_TIMESTAMP);
+            const useBom = !!config.get(CONFIG_CSV_USE_BOM);
+            const useComment = !!config.get(CONFIG_CSV_USE_COMMENT);
+            const useCommentTimestamp = !!config.get(CONFIG_CSV_USE_COMMENT_TIMESTAMP);
 
             // Get the CSV file or create one
             let csvData = await this.getCsvFile(true);

--- a/src/helpers/CsvHelper.ts
+++ b/src/helpers/CsvHelper.ts
@@ -166,7 +166,7 @@ export default class CsvHelper {
       }
 
       for (const resx of csvHeaders.resxNames) {
-        if (resourceName === resx.key && rowData[resx.idx] === "") {
+        if (resourceName === resx.key && !rowData[resx.idx]) {
           rowData[resx.idx] = "x"; // Specify that the key is used in the specified resource
           rowModified = true;
         }

--- a/src/helpers/CsvHelper.ts
+++ b/src/helpers/CsvHelper.ts
@@ -52,18 +52,27 @@ export default class CsvHelper {
    * @param delimiter 
    * @param fileExtension 
    */
-  public static createCsvFile(localeFiles: vscode.Uri[], resource: LocalizedResourceValue, csvFileLocation: string, delimiter: string, fileExtension: string, useBom: boolean): string {
+  public static createCsvFile(localeFiles: vscode.Uri[], resource: LocalizedResourceValue, csvFileLocation: string, delimiter: string, fileExtension: string
+    , useBom: boolean, useComment: boolean): string {
     const locales = localeFiles.map(f => {
       const filePath = f.path.substring(f.path.lastIndexOf("/") + 1);
       return `${LOCALE_HEADER} ${filePath.replace(`.${fileExtension}`, "")}`;
     });
     // Create the headers for the CSV file
     const headers = ["key", ...locales, resource.key];
+
+    // add comment column if feature is enabled
+    if (useComment)
+      headers.push("comment");
+
     const filePath = ProjectFileHelper.getAbsPath(csvFileLocation);
     const bom = useBom ? UTF8_BOM : '';
     fs.writeFileSync(filePath, bom + headers.join(delimiter));
     return headers.join(delimiter);
   }
+
+  // use current timestamp as default comment for the new strings
+  private static makeDefaultComment = () => new Date().toISOString().split('.')[0];
 
   /**
    * Update the CSV data based on the retrieved locale pairs
@@ -75,19 +84,36 @@ export default class CsvHelper {
    * @param resourceName 
    * @param delimiter 
    */
-  public static updateData(csvData: string[][], keyValuePairs: LocaleKeyValue[], localeName: string, resourceName: string): string[][] {
-    const rowDefinition = this.getRowDefinition(csvData);
-    if (rowDefinition) {
+  public static updateData(csvData: string[][], keyValuePairs: LocaleKeyValue[], localeName: string, resourceName: string, 
+    useComment?: boolean, useCommentTimestamp?: boolean): string[][] {
+
+    const csvHeaders = this.getHeaders(csvData);
+
+    // add comment column if feature is enabled
+    if (useComment && csvHeaders && csvHeaders.commentIdx === null) {
+      for (let rowIdx = 0; rowIdx < csvData.length; ++rowIdx) {
+        if (rowIdx === 0) {
+          csvData[rowIdx].push('comment');
+          csvHeaders.commentIdx = csvData[rowIdx].length - 1;
+        } else {
+          csvData[rowIdx].push('');
+        }
+      }
+    }
+
+    const comment = useComment && useCommentTimestamp ? this.makeDefaultComment() : '';
+    
+    if (csvHeaders && csvHeaders.keyIdx !== null) {
       // Start looping over the keyValuePairs
       for (const keyValue of keyValuePairs) {
-        const rowIdx = this.findRowForKey(csvData, keyValue.key, rowDefinition.indexOf("key"));
+        const rowIdx = this.findRowForKey(csvData, keyValue.key, csvHeaders.keyIdx);
         // Check if rowIdx has been found
         if (rowIdx) {
           // Update the row data
-          csvData = this.updateDataRow(csvData, rowIdx, rowDefinition, keyValue, localeName, resourceName);
+          csvData = this.updateDataRow(csvData, rowIdx, csvHeaders, keyValue, localeName, resourceName, comment);
         } else {
           // Key wasn't found, adding a new data row
-          csvData = this.addDataRow(csvData, rowDefinition, keyValue, localeName, resourceName);
+          csvData = this.addDataRow(csvData, csvHeaders, keyValue, localeName, resourceName, comment);
         }
       }
     }
@@ -125,20 +151,28 @@ export default class CsvHelper {
    * @param localeName 
    * @param resourceName 
    */
-  private static updateDataRow(csvData: string[][], rowIndex: number, rowDefinition: string[], keyValue: LocaleKeyValue, localeName: string, resourceName: string): string[][] {
+  private static updateDataRow(csvData: string[][], rowIndex: number, csvHeaders: LocaleCsvInfo, keyValue: LocaleKeyValue, localeName: string, resourceName: string
+    , comment: string): string[][] {
     // Get the row
     let rowData = csvData[rowIndex];
     if (rowData) {
-      for (let i = 0; i <= rowDefinition.length; i++) {
-        // Get the row
-        const header = rowDefinition[i];
-        if (header === localeName && rowData[i] === "") {
-          rowData[i] = keyValue.value; // Add the locale value to the CSV data if it was empty
-        } else if (header === resourceName && rowData[i] === "") {
-          // Specify that the key is used in the specified resource. 
-          // This allows the locale key to be used by multiple resources.
-          rowData[i] = "x"; 
+      let rowModified = false;
+
+      for (const locale of csvHeaders.localeIdx) {
+        if (locale.key === localeName && rowData[locale.idx] === "") {
+          rowData[locale.idx] = keyValue.value;
+          rowModified = true;
         }
+      }
+
+      for (const resx of csvHeaders.resxNames) {
+        if (resourceName === resx.key && rowData[resx.idx] === "") {
+          rowData[resx.idx] = "x"; // Specify that the key is used in the specified resource
+          rowModified = true;
+        }
+      }
+      if (comment && csvHeaders.commentIdx !== null && rowModified) {
+        rowData[csvHeaders.commentIdx] = comment;
       }
     }
 
@@ -154,24 +188,27 @@ export default class CsvHelper {
    * @param localeName 
    * @param resourceName 
    */
-  private static addDataRow(csvData: string[][], rowDefinition: string[], keyValue: LocaleKeyValue, localeName: string, resourceName: string): string[][] {
+  private static addDataRow(csvData: string[][], csvHeaders: LocaleCsvInfo, keyValue: LocaleKeyValue, localeName: string, resourceName: string
+    , comment: string): string[][] {
     let rowData = [];
-    for (const header of rowDefinition) {
-      if (header === "key") { 
-        rowData.push(keyValue.key); // Add the locale key to the CSV data
-      } else if (header === localeName) {
-        rowData.push(keyValue.value); // Add the locale value to the CSV data
-      } else if (header === resourceName) {
-        rowData.push("x"); // Specify that the key is used in the specified resource
-      } else {
-        rowData.push(""); // All other values can be empty
+    if (csvHeaders.keyIdx !== null) {
+
+      rowData[csvHeaders.keyIdx] = keyValue.key;
+
+      for (const locale of csvHeaders.localeIdx) {
+        rowData[locale.idx] = keyValue.value; // Add the locale key to the CSV data
       }
-    }
-    
-    // Check if rowData length is equal to rowDefinition length
-    if (rowData.length === rowDefinition.length) {
+
+      for (const resx of csvHeaders.resxNames) {
+        if (resourceName === resx.key) {
+          rowData[resx.idx] = "x"; // Specify that the key is used in the specified resource
+        }
+      }
+      if (comment && csvHeaders.commentIdx !== null)
+        rowData[csvHeaders.commentIdx] = comment;
+
       // Add the new row
-      const insertRow = this.findInsertRowForKey(csvData, keyValue.key, rowDefinition.indexOf("key"))
+      const insertRow = this.findInsertRowForKey(csvData, keyValue.key, csvHeaders.keyIdx!)
       csvData.splice(insertRow, 0, rowData);
     }
 
@@ -219,7 +256,7 @@ export default class CsvHelper {
    * @param csvHeaders 
    */
   private static processCsvData(csvData: string[][], csvHeaders: LocaleCsvInfo): LocaleCsvData | null {
-    if (csvHeaders.keyIdx !== null) { 
+    if (csvHeaders.keyIdx !== null) {
       const localeData: LocaleCsvData = {};
       // Create all the required locale data
       for (const locale of csvHeaders.localeIdx) {
@@ -238,6 +275,7 @@ export default class CsvHelper {
               if (resxValue && resxValue.toLowerCase() === "x") {
                 localeData[locale.key].push({
                   key: row[csvHeaders.keyIdx] || null,
+                  comment: csvHeaders.commentIdx !== null ? row[csvHeaders.commentIdx] : null,
                   label: row[locale.idx] || null,
                   resx: resx.key || null
                 });
@@ -259,12 +297,13 @@ export default class CsvHelper {
    * 
    * @param csvData 
    */
-  private static getHeaders (csvData: string[][]): LocaleCsvInfo | null {
+  private static getHeaders(csvData: string[][]): LocaleCsvInfo | null {
     if (csvData && csvData.length > 0) {
       const firstRow = csvData[0];
       if (firstRow) {
         const headerInfo: LocaleCsvInfo = {
           keyIdx: null,
+          commentIdx: null,
           localeIdx: [],
           resxNames: []
         };
@@ -275,6 +314,8 @@ export default class CsvHelper {
             // Add the key index to the object
             if (cell.toLowerCase() === "key") {
               headerInfo.keyIdx = i;
+            } else if (cell.toLowerCase() === "comment") {
+              headerInfo.commentIdx = i;
             } else if (cell.toLowerCase().startsWith(LOCALE_HEADER.toLowerCase())) {
               headerInfo.localeIdx.push({
                 key: cell.toLowerCase().replace(LOCALE_HEADER.toLowerCase(), "").trim(),
@@ -294,24 +335,4 @@ export default class CsvHelper {
     return null;
   }
 
-  /**
-   * Get row definition
-   * 
-   * @param csvData
-   */
-  private static getRowDefinition (csvData: string[][]): string[] | null {
-    if (csvData && csvData.length > 0) {
-      const firstRow = csvData[0];
-      return firstRow.map(cell => {
-        if (cell.toLowerCase() === "key") {
-          return cell.toLowerCase();
-        } else if (cell.toLowerCase().startsWith(LOCALE_HEADER.toLowerCase())) {
-          return cell.toLowerCase().replace(LOCALE_HEADER.toLowerCase(), "").trim();
-        } else {
-          return cell;
-        }
-      });
-    }
-    return null;
-  }
 }

--- a/src/helpers/CsvHelper.ts
+++ b/src/helpers/CsvHelper.ts
@@ -159,7 +159,7 @@ export default class CsvHelper {
       let rowModified = false;
 
       for (const locale of csvHeaders.localeIdx) {
-        if (locale.key === localeName && rowData[locale.idx] === "") {
+        if (locale.key === localeName && !rowData[locale.idx]) {
           rowData[locale.idx] = keyValue.value;
           rowModified = true;
         }
@@ -196,7 +196,9 @@ export default class CsvHelper {
       rowData[csvHeaders.keyIdx] = keyValue.key;
 
       for (const locale of csvHeaders.localeIdx) {
-        rowData[locale.idx] = keyValue.value; // Add the locale key to the CSV data
+        if (locale.key === localeName) {
+          rowData[locale.idx] = keyValue.value; // Add the locale key to the CSV data
+        }
       }
 
       for (const resx of csvHeaders.resxNames) {

--- a/src/helpers/ExportLocaleHelper.ts
+++ b/src/helpers/ExportLocaleHelper.ts
@@ -15,7 +15,8 @@ export default class ExportLocaleHelper {
    * @param delimiter
    * @param resourceName
    */
-  public static async startExport(err: any | Error, csvData: string[][], localeFiles: vscode.Uri[], csvLocation: string, delimiter: string, resourceName: string, useBom: boolean): Promise<void> {
+  public static async startExport(err: any | Error, csvData: string[][], localeFiles: vscode.Uri[], csvLocation: string, delimiter: string, resourceName: string, useBom: boolean
+    , useComment: boolean, useCommentTimestamp: boolean): Promise<void> {
     // Start looping over the JS Locale files
     for (const localeFile of localeFiles) {
       const localeData = await vscode.workspace.openTextDocument(localeFile);
@@ -26,7 +27,7 @@ export default class ExportLocaleHelper {
           const fileName = path.basename(localeData.fileName);
           const localeName = fileName.split('.').slice(0, -1).join('.');
           // Start adding/updating the key and values to the CSV data
-          csvData = CsvHelper.updateData(csvData, keyValuePairs, localeName, resourceName);
+          csvData = CsvHelper.updateData(csvData, keyValuePairs, localeName, resourceName, useComment, useCommentTimestamp);
         }
       }
     }

--- a/src/helpers/ExtensionSettings.ts
+++ b/src/helpers/ExtensionSettings.ts
@@ -8,3 +8,5 @@ export const OPTION_IMPORT_ALL = "Import to all";
 
 export const CONFIG_CSV_USE_BOM = "csvUseBom";
 export const UTF8_BOM = '\ufeff';
+export const CONFIG_CSV_USE_COMMENT = "csvUseComment";
+export const CONFIG_CSV_USE_COMMENT_TIMESTAMP = "csvUseCommentTimestamp";

--- a/src/helpers/ImportLocaleHelper.ts
+++ b/src/helpers/ImportLocaleHelper.ts
@@ -6,6 +6,7 @@ import { LocalizedResourceValue } from "../models/Config";
 import { LocaleCsvData, LocaleData } from "../models/LocaleCsvInfo";
 import ProjectFileHelper from "./ProjectFileHelper";
 import { CONFIG_KEY, CONFIG_FILE_EXTENSION } from "./ExtensionSettings";
+import TextHelper from "./TextHelper";
 
 export default class ImportLocaleHelper {
 
@@ -110,10 +111,11 @@ define([], () => {
       // Check if the line was found, add the key and save the file
       if (!fileContents.includes(`${localeKey}: string;`)) {
         applyEdit = true;
-        const getLinePos = fileLines[startPos + 1].search(/\S|$/);
+        const getLine = TextHelper.findInsertPosition(fileLines, localeKey!, TextHelper.FindPositionTs);
+        const getLinePos = fileLines[getLine + 1].search(/\S|$/);
         // Create the data to insert in the file
         const newLineData = `${localeKey}: string;\r\n${' '.repeat(getLinePos)}`;
-        edit.insert(fileData.uri, new vscode.Position((startPos + 1), getLinePos), newLineData);
+        edit.insert(fileData.uri, new vscode.Position(getLine+1, getLinePos), newLineData);
       }
     }
 

--- a/src/models/LocaleCsvInfo.ts
+++ b/src/models/LocaleCsvInfo.ts
@@ -1,6 +1,7 @@
 
 export interface LocaleCsvInfo {
   keyIdx: number | null;
+  commentIdx: number | null;
   localeIdx: HeaderIdx[];
   resxNames: HeaderIdx[];
 }
@@ -16,6 +17,7 @@ export interface LocaleCsvData {
 
 export interface LocaleData {
   key: string | null;
+  comment: string | null;
   label: string | null;
   resx: string | null;
 }


### PR DESCRIPTION
Related issue: #11 

Add support for "comments" column (preserved on save/load). Also, when you add strings there is an option to auto-fill this column with current timestamp so that the translator knows there are new strings.

- csvUseComment : Enable comment column in CSV. You can use this column for notices, such as 'translated' or 'new'. The column is "forcefully" added on the next update of the CSV file, if this option is enabled.
- csvUseCommentTimestamp :  Auto-fill comment column with current timestamp when new strings are added. The field "comment" is filled with current timestamps for the newly extracted strings.

The second commit is minor is for sorting (was missing when you do "mass-import")

Please kindly verify that `updateDataRow` and `addDataRow` functions are not broken (I think I've tested properly, but it's better to check them anyways). I had to modify them to support comments (use `getHeaders` instead of `getRowDefinition`)