### PR TITLE
Add a setting to allow pushing strings from translated .js files back to CSV/XLS

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ The extension has the following settings which you can configure to your own pre
 | `spfxLocalization.csvUseBom` | Use UTF8 BOM marker for CSV/XLSX files. Can be useful on Windows to make UTF8 CSV/XLSX files recognizable by Excel for example. | boolean | `false` |
 | `spfxLocalization.csvUseComment` | Enable comment column in CSV/XLSX. You can use this column for notices, such as "translated" or "new". | boolean | `false` |
 | `spfxLocalization.csvUseTimestamp` | Auto-fill timestamp column with current timestamp when new strings are added. | boolean | `false` |
+| `spfxLocalization.allowOverwrite` | Allow project file values to overwrite existing CSV/XLSX values during export. When disabled, CSV values are preserved and a warning is shown. | boolean | `false` |
 
 
 ## How to use this extension

--- a/package.json
+++ b/package.json
@@ -67,6 +67,11 @@
           "default": false,
           "description": "Specify if you want to automatically export to the CSV/XLSX file when creating new labels."
         },
+        "spfxLocalization.allowOverwrite": {
+          "type": "boolean",
+          "default": false,
+          "description": "Allow project file values to overwrite existing CSV/XLSX values during export. When disabled, CSV values are preserved and a warning is shown."
+        },
         "spfxLocalization.localeFileExtension": {
           "type": "string",
           "default": "js",

--- a/src/helpers/CsvDataExcel.ts
+++ b/src/helpers/CsvDataExcel.ts
@@ -47,6 +47,25 @@ export class CsvDataExcel implements ICsvData {
 
   addRow(r: number) {
     this.ws.insertRow(r + 1, Array(this.colCount).join('.').split('.'));
+    
+    // Expand table if it exists
+    const tables = this.ws.getTables();
+    if (tables?.length > 0) {
+      for (const it of tables) {
+        const table = (it as any)?.table;
+        if (table?.tableRef) {
+          const match = table.tableRef.match(/([A-Z]+)(\d+):([A-Z]+)(\d+)/);
+          if (match) {
+            const [, startCol, startRow, endCol, endRow] = match;
+            const endRowNum = parseInt(endRow);
+            // Check if inserted row is within or after table range
+            if (r + 1 <= endRowNum + 1) {
+              table.tableRef = `${startCol}${startRow}:${endCol}${endRowNum + 1}`;
+            }
+          }
+        }
+      }
+    }
   }
 
   get rowCount(): number {

--- a/src/helpers/ExtensionSettings.ts
+++ b/src/helpers/ExtensionSettings.ts
@@ -11,3 +11,4 @@ export const CONFIG_CSV_USE_BOM = "csvUseBom";
 export const UTF8_BOM = '\ufeff';
 export const CONFIG_CSV_USE_COMMENT = "csvUseComment";
 export const CONFIG_CSV_USE_TIMESTAMP = "csvUseTimestamp";
+export const CONFIG_ALLOW_OVERWRITE = "allowOverwrite";

--- a/src/helpers/ImportLocaleHelper.ts
+++ b/src/helpers/ImportLocaleHelper.ts
@@ -30,6 +30,7 @@ export default class ImportLocaleHelper {
     let resourcePath = ProjectFileHelper.getResourcePath(resx);
 
     // Start creating the files
+    let filesCreated = false;
     for (const key in localeData) {
       const localLabels = localeData[key];
       if (key && localLabels && localLabels.length > 0) {
@@ -51,10 +52,14 @@ define([], () => {
 });`;
           // Start creating the file
           const fileLocation = path.join(vscode.workspace.rootPath || __dirname, resourcePath, `${key}.${fileExtension}`);
-          fs.writeFileSync(fileLocation, fileContents, { encoding: "utf8" });
-          Logging.info(`Localization labels have been imported.`);
+          await fs.promises.writeFile(fileLocation, fileContents, { encoding: "utf8" });
+          filesCreated = true;
         }
       }
+    }
+    
+    if (filesCreated) {
+      Logging.info(`Localization labels have been imported.`);
     }
   }
 


### PR DESCRIPTION
This adds an option to allow overwriting data in CSV/Excel.

<img width="1351" height="160" alt="image" src="https://github.com/user-attachments/assets/76602bcf-dd1d-4421-8e55-ac6e1be61673" />


## Motivation

The motivation: now you can use AI agents to translate things in many places, and they work with source code. 
But bringing those _automated_ translations back to CSV/Excel file (for manual review/corrections) is a bit problematic.

This setting allows the extension to **overwrite** strings in Excel. 
The setting is OFF by default (non-breaking change).

## Overview

Added a new setting `spfxLocalization.allowOverwrite` to control whether project file values can overwrite existing CSV/XLSX values during export operations.

## Setting Details

- **Name**: `spfxLocalization.allowOverwrite`
- **Type**: boolean
- **Default**: `false`
- **Description**: Allow project file values to overwrite existing CSV/XLSX values during export. When disabled, CSV values are preserved and a warning is shown.

## Behavior

### When `allowOverwrite` is `false` (default)
- Existing CSV/XLSX values are preserved during export
- If a project file contains different values, a warning is logged
- Users maintain control over their translated content in CSV files

### When `allowOverwrite` is `true`
- Project file values will overwrite existing CSV/XLSX values during export
- Useful when project files are the source of truth
- Allows automatic synchronization from code to CSV

## Implementation

The setting is checked in `CsvHelper.updateDataRow()` method when processing locale key-value pairs during CSV export operations.

#  small extra fixes

**ImportLocaleHelper.ts**: Starting with some version, vscode stopped showing the notification about files translated (too short notice), but started hiding it in the toolbar instead. Changed the Logger.info for importing file to show final notification when all files are processed.

**CsvDataExcel.ts:** fix the issue with XLSX support: if there is a table defined in Excel covering the rows, adding new rows did not grow that table. Now it does.